### PR TITLE
Corrige intitule gestionnaire Nginx

### DIFF
--- a/panels.html
+++ b/panels.html
@@ -130,7 +130,7 @@
                                 </h3>
                                 <p>Automatisation de Radarr/Sonarr.</p>
                             </a>
-                            <a href="http://45.155.54.165:81/" target="_blank" rel="noopener noreferrer" class="service-button" aria-label="Ouvrir le manager Nginx VPS (serveur ltn0)">
+                            <a href="http://45.155.54.165:81/" target="_blank" rel="noopener noreferrer" class="service-button" aria-label="Ouvrir le gestionnaire Nginx VPS (serveur ltn0)">
                                 <h3>Nginx VPS
                                     <span class="server-status-card" data-server-id="ltn0">
                                         <div class="status-indicator"></div>
@@ -138,7 +138,7 @@
                                         <div class="status-tooltip"></div>
                                     </span>
                                 </h3>
-                                <p>Manageur de proxy.</p>
+                                <p>Gestionnaire de proxy.</p>
                             </a>
                             <a href="https://tdarr.lynnternet.cloud" target="_blank" rel="noopener noreferrer" class="service-button" aria-label="Ouvrir Tdarr (serveur ltn1)">
                                 <h3>Tdarr


### PR DESCRIPTION
## Summary
- Harmonise la traduction francophone du panneau Nginx en remplaçant "Manageur de proxy" par "Gestionnaire de proxy"
- Met à jour l'attribut `aria-label` pour refléter le nouveau libellé "gestionnaire Nginx VPS"

## Testing
- `npm test` (échoue : package.json introuvable)


------
https://chatgpt.com/codex/tasks/task_b_68a50050d9048331b3a0ec10811b43bf