### PR TITLE
docs: improve README with project overview and Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-autistic useless project
+# Lynnternet Dashboard
+
+## Objectif
+Ce projet propose un tableau de bord pour visualiser l'état et les informations de plusieurs serveurs.
+
+## Stack
+- **Frontend** : HTML, CSS et JavaScript
+- **Serveur** : Nginx
+
+## Installation
+1. Cloner le dépôt :
+   ```bash
+   git clone https://example.com/lynnternet.git
+   cd lynnternet
+   ```
+2. Construire l'image Docker :
+   ```bash
+   docker build -t lynnternet .
+   ```
+
+## Usage
+Lancer le conteneur :
+```bash
+ docker run -p 8080:80 lynnternet
+```
+Le tableau de bord est ensuite accessible sur http://localhost:8080.
+
+## Licence
+Ce projet est distribué sous licence MIT.


### PR DESCRIPTION
## Summary
- Describe server dashboard objective and technology stack
- Add Docker installation and usage instructions
- Document project license

## Testing
- `docker build -t lynnternet .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a50070a93083318a1053c33aece5de