### PR TITLE
Reset focus-visible on pointer interactions

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,6 +35,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function enhanceAccessibility() {
       let usedKeyboard = false;
       window.addEventListener('keydown', e => { if (e.key === 'Tab') usedKeyboard = true; });
+      window.addEventListener('pointerdown', () => {
+        usedKeyboard = false;
+        const active = document.activeElement;
+        if (active && active.classList) active.classList.remove('focus-visible');
+      });
       document.addEventListener('focusin', e => {
         if (!usedKeyboard) return;
         const el = e.target;


### PR DESCRIPTION
## Summary
- Reset keyboard navigation flag on pointerdown events
- Remove `focus-visible` class when interacting with the pointer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a50061aa68833192cedebf64abe92f