### PR TITLE
Extract sanitizeId utility and add tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&family=Unbounded:wght@500;700&display=swap" rel="stylesheet">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js"></script>
     <script defer src="main.js"></script>
-    <script defer src="multiServer.js"></script>
+    <script type="module" defer src="multiServer.js"></script>
 </head>
 <body>
     <div id="nav-placeholder"></div>

--- a/multiServer.js
+++ b/multiServer.js
@@ -1,4 +1,6 @@
 'use strict';
+import { sanitizeId } from './utils.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const SERVERS = [
     { id: 'ltn1', name: 'ltn1', api: 'https://ltn1.lynnternet.cloud/api/stats', description: 'Plex media server', services: 'plex' },
@@ -26,7 +28,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const UPLOAD_COLOR = 'rgb(255, 99, 132)';
 
   const makeAlpha = (color, a) => color.replace('rgb', 'rgba').replace(')', `, ${a})`);
-  const sanitizeId = s => String(s).trim().replace(/[^\w-]+/g, '-');
   const setText = (el, t) => { if (el && el.textContent !== t) el.textContent = t; };
 
   let writeQueue = [];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lynnternet",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/panels.html
+++ b/panels.html
@@ -14,7 +14,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&family=Unbounded:wght@500;700&display=swap" rel="stylesheet">
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js"></script>
     <script defer src="main.js"></script>
-    <script defer src="multiServer.js"></script>
+    <script type="module" defer src="multiServer.js"></script>
 </head>
 <body>
     <div id="nav-placeholder"></div>

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { sanitizeId } from '../utils.js';
+
+test('converts spaces to hyphens', () => {
+  assert.strictEqual(sanitizeId('hello world'), 'hello-world');
+});
+
+test('replaces special characters', () => {
+  assert.strictEqual(sanitizeId('hello@#$world'), 'hello-world');
+});
+
+test('preserves uppercase letters', () => {
+  assert.strictEqual(sanitizeId('Hello World'), 'Hello-World');
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,3 @@
+export function sanitizeId(s) {
+  return String(s).trim().replace(/[^\w-]+/g, '-');
+}


### PR DESCRIPTION
## Summary
- extract `sanitizeId` into new `utils.js` module and import it in `multiServer.js`
- load `multiServer.js` as an ES module in HTML
- add Node tests for `sanitizeId` and npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5007da2808331af029f35a1f38e68