### PR TITLE
Add security rel attributes to footer links

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -32,7 +32,7 @@
         </div>
     </div>
     <div class="footer-social">
-        <a href="https://github.com/literalynn" target="_blank" class="icon">
+        <a href="https://github.com/literalynn" target="_blank" rel="noopener noreferrer" class="icon">
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M12 .296a12 12 0 0 0-3.793 23.4c.6.111.82-.26.82-.58
                      0-.286-.011-1.243-.017-2.255-3.338.726-4.042-1.416-4.042-1.416
@@ -46,12 +46,12 @@
                      0 1.606-.014 2.9-.014 3.296 0 .322.216.698.826.58A12 12 0 0 0 12 .296Z"/>
             </svg>
         </a>
-        <a href="https://x.com/literalynn" target="_blank" class="icon">
+        <a href="https://x.com/literalynn" target="_blank" rel="noopener noreferrer" class="icon">
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path d="M21.543 7.104c.015.211.015.423.015.636 0 6.507-4.954 14.01-14.01 14.01v-.003A13.94 13.94 0 0 1 0 19.539a9.88 9.88 0 0 0 7.287-2.041 4.93 4.93 0 0 1-4.6-3.42 4.916 4.916 0 0 0 2.223-.084A4.926 4.926 0 0 1 .96 9.167v-.062a4.887 4.887 0 0 0 2.235.616A4.928 4.928 0 0 1 1.67 3.148 13.98 13.98 0 0 0 11.82 8.292a4.929 4.929 0 0 1 8.39-4.49 9.868 9.868 0 0 0 3.128-1.196 4.941 4.941 0 0 1-2.165 2.724A9.828 9.828 0 0 0 24 4.555a10.019 10.019 0 0 1-2.457 2.549z"/>
             </svg>
         </a>
-        <a href="https://twitch.tv/literalynn" target="_blank" class="icon">
+        <a href="https://twitch.tv/literalynn" target="_blank" rel="noopener noreferrer" class="icon">
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M2.149 0 .537 4.119V20.955h5.731V24h3.224l3.045-3.045h4.657l6.269-6.269V0H2.149Zm19.164 13.612-3.582 3.582h-5.731l-3.045 3.045v-3.045H4.119V1.149h17.194v12.463ZM17.731 6.269v6.262h-2.149V6.269h2.149Zm-5.731 0v6.262h-2.149V6.269h2.149Z"/>
             </svg>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to footer's external links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a508fa75788331bc46880bda794ce9