### PR TITLE
Use CSS class for centered placeholder text

### DIFF
--- a/info.html
+++ b/info.html
@@ -22,7 +22,7 @@
             </header>
 
             <main>
-                <center>soon</center>
+                <div class="text-center">soon</div>
             </main>
         </div>
         <div class="container">

--- a/style.css
+++ b/style.css
@@ -75,6 +75,7 @@ body::after {
     flex-direction: column;
 }
 main { flex-grow: 1; width: 100%; }
+.text-center { text-align: center; }
 #nav-placeholder {
     position: fixed;
     top: 1rem;

--- a/tuto.html
+++ b/tuto.html
@@ -21,7 +21,7 @@
                 <h1>Guides</h1>
             </header>
             <main>
-                <center>soon</center>
+                <div class="text-center">soon</div>
             </main>
         </div>
         <div class="container">


### PR DESCRIPTION
## Summary
- Replace deprecated `<center>` tags in `info.html` and `tuto.html` with `<div class="text-center">`
- Add reusable `.text-center` class in `style.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a508f7c4b08331b100593c985388bb