### PR TITLE
Add SRI hashes to external assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&family=Unbounded:wght@500;700&display=swap" rel="stylesheet">
-    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&family=Unbounded:wght@500;700&display=swap" rel="stylesheet" integrity="sha384-QBFDD5MbkNR5SkI3YlvvkevUZRI0sPUHpBo/JI+58o/GbyH1n8USInZsxcPuAmoI" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js" integrity="sha384-XcdcwHqIPULERb2yDEM4R0XaQKU3YnDsrTmjACBZyfdVVqjh6xQ4/DCMd7XLcA6Y" crossorigin="anonymous"></script>
     <script defer src="main.js"></script>
     <script defer src="multiServer.js"></script>
 </head>

--- a/panels.html
+++ b/panels.html
@@ -11,8 +11,8 @@
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&family=Unbounded:wght@500;700&display=swap" rel="stylesheet">
-    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&family=Unbounded:wght@500;700&display=swap" rel="stylesheet" integrity="sha384-QBFDD5MbkNR5SkI3YlvvkevUZRI0sPUHpBo/JI+58o/GbyH1n8USInZsxcPuAmoI" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js" integrity="sha384-XcdcwHqIPULERb2yDEM4R0XaQKU3YnDsrTmjACBZyfdVVqjh6xQ4/DCMd7XLcA6Y" crossorigin="anonymous"></script>
     <script defer src="main.js"></script>
     <script defer src="multiServer.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- secure external resources by adding SHA-384 SRI hashes and `crossorigin` attributes for Google Fonts and Chart.js scripts in key HTML pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a508fce2dc8331b74e756204011f3a